### PR TITLE
Upgrade to TJpgDec R0.03.

### DIFF
--- a/tjpgd.c
+++ b/tjpgd.c
@@ -1,11 +1,11 @@
 /*----------------------------------------------------------------------------/
-/ TJpgDec - Tiny JPEG Decompressor R0.01d                     (C)ChaN, 2020
+/ TJpgDec - Tiny JPEG Decompressor R0.03                      (C)ChaN, 2021
 /-----------------------------------------------------------------------------/
 / The TJpgDec is a generic JPEG decompressor module for tiny embedded systems.
 / This is a free software that opened for education, research and commercial
 /  developments under license policy of following terms.
 /
-/  Copyright (C) 2020, ChaN, all right reserved.
+/  Copyright (C) 2021, ChaN, all right reserved.
 /
 / * The TJpgDec module is a free software and there is NO WARRANTY.
 / * No restriction on use. You can use, modify and redistribute it for
@@ -18,16 +18,25 @@
 / Sep 03, 2012 R0.01b Added JD_TBLCLIP option.
 / Mar 16, 2019 R0.01c Supprted stdint.h.
 / Jul 01, 2020 R0.01d Fixed wrong integer type usage.
+/ May 08, 2021 R0.02  Supprted grayscale image. Separated configuration options.
+/ Jun 11, 2021 R0.02a Some performance improvement.
+/ Jul 01, 2021 R0.03  Added JD_FASTDECODE option.
+/                     Some performance improvement.
 /----------------------------------------------------------------------------*/
 
 #include "tjpgd.h"
 
 
+#if JD_FASTDECODE == 2
+#define HUFF_BIT	10	/* Bit length to apply fast huffman decode */
+#define HUFF_LEN	(1 << HUFF_BIT)
+#define HUFF_MASK	(HUFF_LEN - 1)
+#endif
+
+
 /*-----------------------------------------------*/
 /* Zigzag-order to raster-order conversion table */
 /*-----------------------------------------------*/
-
-#define ZIG(n)	Zig[n]
 
 static const uint8_t Zig[64] = {	/* Zigzag-order to raster-order conversion table */
 	 0,  1,  8, 16,  9,  2,  3, 10, 17, 24, 32, 25, 18, 11,  4,  5,
@@ -42,8 +51,6 @@ static const uint8_t Zig[64] = {	/* Zigzag-order to raster-order conversion tabl
 /* Input scale factor of Arai algorithm            */
 /* (scaled up 16 bits for fixed point operations)  */
 /*-------------------------------------------------*/
-
-#define IPSF(n)	Ipsf[n]
 
 static const uint16_t Ipsf[64] = {	/* See also aa_idct.png */
 	(uint16_t)(1.00000*8192), (uint16_t)(1.38704*8192), (uint16_t)(1.30656*8192), (uint16_t)(1.17588*8192), (uint16_t)(1.00000*8192), (uint16_t)(0.78570*8192), (uint16_t)(0.54120*8192), (uint16_t)(0.27590*8192),
@@ -107,13 +114,10 @@ static const uint8_t Clip8[1024] = {
 
 #else	/* JD_TBLCLIP */
 
-inline uint8_t BYTECLIP (
-	int val
-)
+static uint8_t BYTECLIP (int val)
 {
-	if (val < 0) val = 0;
-	if (val > 255) val = 255;
-
+	if (val < 0) return 0;
+	if (val > 255) return 255;
 	return (uint8_t)val;
 }
 
@@ -127,18 +131,18 @@ inline uint8_t BYTECLIP (
 
 static void* alloc_pool (	/* Pointer to allocated memory block (NULL:no memory available) */
 	JDEC* jd,				/* Pointer to the decompressor object */
-	unsigned int nd			/* Number of bytes to allocate */
+	size_t ndata			/* Number of bytes to allocate */
 )
 {
 	char *rp = 0;
 
 
-	nd = (nd + 3) & ~3;			/* Align block size to the word boundary */
+	ndata = (ndata + 3) & ~3;			/* Align block size to the word boundary */
 
-	if (jd->sz_pool >= nd) {
-		jd->sz_pool -= nd;
+	if (jd->sz_pool >= ndata) {
+		jd->sz_pool -= ndata;
 		rp = (char*)jd->pool;			/* Get start of available memory pool */
-		jd->pool = (void*)(rp + nd);	/* Allocate requierd bytes */
+		jd->pool = (void*)(rp + ndata);	/* Allocate requierd bytes */
 	}
 
 	return (void*)rp;	/* Return allocated memory block (NULL:no memory to allocate) */
@@ -154,11 +158,11 @@ static void* alloc_pool (	/* Pointer to allocated memory block (NULL:no memory a
 static JRESULT create_qt_tbl (	/* 0:OK, !0:Failed */
 	JDEC* jd,				/* Pointer to the decompressor object */
 	const uint8_t* data,	/* Pointer to the quantizer tables */
-	unsigned int ndata		/* Size of input data */
+	size_t ndata			/* Size of input data */
 )
 {
-	unsigned int i;
-	uint8_t d, z;
+	unsigned int i, zi;
+	uint8_t d;
 	int32_t *pb;
 
 
@@ -172,8 +176,8 @@ static JRESULT create_qt_tbl (	/* 0:OK, !0:Failed */
 		if (!pb) return JDR_MEM1;				/* Err: not enough memory */
 		jd->qttbl[i] = pb;						/* Register the table */
 		for (i = 0; i < 64; i++) {				/* Load the table */
-			z = ZIG(i);							/* Zigzag-order to raster-order conversion */
-			pb[z] = (int32_t)((uint32_t)*data++ * IPSF(z));	/* Apply scale factor of Arai algorithm to the de-quantizers */
+			zi = Zig[i];						/* Zigzag-order to raster-order conversion */
+			pb[zi] = (int32_t)((uint32_t)*data++ * Ipsf[zi]);	/* Apply scale factor of Arai algorithm to the de-quantizers */
 		}
 	}
 
@@ -190,10 +194,11 @@ static JRESULT create_qt_tbl (	/* 0:OK, !0:Failed */
 static JRESULT create_huffman_tbl (	/* 0:OK, !0:Failed */
 	JDEC* jd,					/* Pointer to the decompressor object */
 	const uint8_t* data,		/* Pointer to the packed huffman tables */
-	unsigned int ndata			/* Size of input data */
+	size_t ndata				/* Size of input data */
 )
 {
-	unsigned int i, j, b, np, cls, num;
+	unsigned int i, j, b, cls, num;
+	size_t np;
 	uint8_t d, *pb, *pd;
 	uint16_t hc, *ph;
 
@@ -210,7 +215,7 @@ static JRESULT create_huffman_tbl (	/* 0:OK, !0:Failed */
 		for (np = i = 0; i < 16; i++) {		/* Load number of patterns for 1 to 16-bit code */
 			np += (pb[i] = *data++);		/* Get sum of code words for each code */
 		}
-		ph = alloc_pool(jd, (unsigned int)(np * sizeof (uint16_t)));/* Allocate a memory block for the code word table */
+		ph = alloc_pool(jd, np * sizeof (uint16_t));/* Allocate a memory block for the code word table */
 		if (!ph) return JDR_MEM1;			/* Err: not enough memory */
 		jd->huffcode[num][cls] = ph;
 		hc = 0;
@@ -225,14 +230,187 @@ static JRESULT create_huffman_tbl (	/* 0:OK, !0:Failed */
 		pd = alloc_pool(jd, np);			/* Allocate a memory block for the decoded data */
 		if (!pd) return JDR_MEM1;			/* Err: not enough memory */
 		jd->huffdata[num][cls] = pd;
-		for (i = 0; i < np; i++) {			/* Load decoded data corresponds to each code ward */
+		for (i = 0; i < np; i++) {			/* Load decoded data corresponds to each code word */
 			d = *data++;
 			if (!cls && d > 11) return JDR_FMT1;
-			*pd++ = d;
+			pd[i] = d;
 		}
+#if JD_FASTDECODE == 2
+		{	/* Create fast huffman decode table */
+			unsigned int span, td, ti;
+			uint16_t *tbl_ac = 0;
+			uint8_t *tbl_dc = 0;
+
+			if (cls) {
+				tbl_ac = alloc_pool(jd, HUFF_LEN * sizeof (uint16_t));	/* LUT for AC elements */
+				if (!tbl_ac) return JDR_MEM1;		/* Err: not enough memory */
+				jd->hufflut_ac[num] = tbl_ac;
+				memset(tbl_ac, 0xFF, HUFF_LEN * sizeof (uint16_t));		/* Default value (0xFFFF: may be long code) */
+			} else {
+				tbl_dc = alloc_pool(jd, HUFF_LEN * sizeof (uint8_t));	/* LUT for AC elements */
+				if (!tbl_dc) return JDR_MEM1;		/* Err: not enough memory */
+				jd->hufflut_dc[num] = tbl_dc;
+				memset(tbl_dc, 0xFF, HUFF_LEN * sizeof (uint8_t));		/* Default value (0xFF: may be long code) */
+			}
+			for (i = b = 0; b < HUFF_BIT; b++) {	/* Create LUT */
+				for (j = pb[b]; j; j--) {
+					ti = ph[i] << (HUFF_BIT - 1 - b) & HUFF_MASK;	/* Index of input pattern for the code */
+					if (cls) {
+						td = pd[i++] | ((b + 1) << 8);	/* b15..b8: code length, b7..b0: zero run and data length */
+						for (span = 1 << (HUFF_BIT - 1 - b); span; span--, tbl_ac[ti++] = (uint16_t)td) ;
+					} else {
+						td = pd[i++] | ((b + 1) << 4);	/* b7..b4: code length, b3..b0: data length */
+						for (span = 1 << (HUFF_BIT - 1 - b); span; span--, tbl_dc[ti++] = (uint8_t)td) ;
+					}
+				}
+			}
+			jd->longofs[num][cls] = i;	/* Code table offset for long code */
+		}
+#endif
 	}
 
 	return JDR_OK;
+}
+
+
+
+
+/*-----------------------------------------------------------------------*/
+/* Extract a huffman decoded data from input stream                      */
+/*-----------------------------------------------------------------------*/
+
+static int huffext (	/* >=0: decoded data, <0: error code */
+	JDEC* jd,			/* Pointer to the decompressor object */
+	unsigned int id,	/* Table ID (0:Y, 1:C) */
+	unsigned int cls	/* Table class (0:DC, 1:AC) */
+)
+{
+	size_t dc = jd->dctr;
+	uint8_t *dp = jd->dptr;
+	unsigned int d, flg = 0;
+
+#if JD_FASTDECODE == 0
+	uint8_t bm, nd, bl;
+	const uint8_t *hb = jd->huffbits[id][cls];	/* Bit distribution table */
+	const uint16_t *hc = jd->huffcode[id][cls];	/* Code word table */
+	const uint8_t *hd = jd->huffdata[id][cls];	/* Data table */
+
+
+	bm = jd->dbit;	/* Bit mask to extract */
+	d = 0; bl = 16;	/* Max code length */
+	do {
+		if (!bm) {		/* Next byte? */
+			if (!dc) {	/* No input data is available, re-fill input buffer */
+				dp = jd->inbuf;	/* Top of input buffer */
+				dc = jd->infunc(jd, dp, JD_SZBUF);
+				if (!dc) return 0 - (int)JDR_INP;	/* Err: read error or wrong stream termination */
+			} else {
+				dp++;	/* Next data ptr */
+			}
+			dc--;		/* Decrement number of available bytes */
+			if (flg) {		/* In flag sequence? */
+				flg = 0;	/* Exit flag sequence */
+				if (*dp != 0) return 0 - (int)JDR_FMT1;	/* Err: unexpected flag is detected (may be collapted data) */
+				*dp = 0xFF;				/* The flag is a data 0xFF */
+			} else {
+				if (*dp == 0xFF) {		/* Is start of flag sequence? */
+					flg = 1; continue;	/* Enter flag sequence, get trailing byte */
+				}
+			}
+			bm = 0x80;		/* Read from MSB */
+		}
+		d <<= 1;			/* Get a bit */
+		if (*dp & bm) d++;
+		bm >>= 1;
+
+		for (nd = *hb++; nd; nd--) {	/* Search the code word in this bit length */
+			if (d == *hc++) {	/* Matched? */
+				jd->dbit = bm; jd->dctr = dc; jd->dptr = dp;
+				return *hd;		/* Return the decoded data */
+			}
+			hd++;
+		}
+		bl--;
+	} while (bl);
+
+#else
+	const uint8_t *hb, *hd;
+	const uint16_t *hc;
+	unsigned int nc, bl, wbit = jd->dbit % 32;
+	uint32_t w = jd->wreg & ((1UL << wbit) - 1);
+
+
+	while (wbit < 16) {	/* Prepare 16 bits into the working register */
+		if (jd->marker) {
+			d = 0xFF;	/* Input stream has stalled for a marker. Generate stuff bits */
+		} else {
+			if (!dc) {	/* Buffer empty, re-fill input buffer */
+				dp = jd->inbuf;						/* Top of input buffer */
+				dc = jd->infunc(jd, dp, JD_SZBUF);
+				if (!dc) return 0 - (int)JDR_INP;	/* Err: read error or wrong stream termination */
+			}
+			d = *dp++; dc--;
+			if (flg) {		/* In flag sequence? */
+				flg = 0;	/* Exit flag sequence */
+				if (d != 0) jd->marker = d;	/* Not an escape of 0xFF but a marker */
+				d = 0xFF;
+			} else {
+				if (d == 0xFF) {		/* Is start of flag sequence? */
+					flg = 1; continue;	/* Enter flag sequence, get trailing byte */
+				}
+			}
+		}
+		w = w << 8 | d;	/* Shift 8 bits in the working register */
+		wbit += 8;
+	}
+	jd->dctr = dc; jd->dptr = dp;
+	jd->wreg = w;
+
+#if JD_FASTDECODE == 2
+	/* Table serch for the short codes */
+	d = (unsigned int)(w >> (wbit - HUFF_BIT));	/* Short code as table index */
+	if (cls) {	/* AC element */
+		d = jd->hufflut_ac[id][d];	/* Table decode */
+		if (d != 0xFFFF) {	/* It is done if hit in short code */
+			jd->dbit = wbit - (d >> 8);	/* Snip the code length */
+			return d & 0xFF;	/* b7..0: zero run and following data bits */
+		}
+	} else {	/* DC element */
+		d = jd->hufflut_dc[id][d];	/* Table decode */
+		if (d != 0xFF) {	/* It is done if hit in short code */
+			jd->dbit = wbit - (d >> 4);	/* Snip the code length  */
+			return d & 0xF;	/* b3..0: following data bits */
+		}
+	}
+
+	/* Incremental serch for the codes longer than HUFF_BIT */
+	hb = jd->huffbits[id][cls] + HUFF_BIT;				/* Bit distribution table */
+	hc = jd->huffcode[id][cls] + jd->longofs[id][cls];	/* Code word table */
+	hd = jd->huffdata[id][cls] + jd->longofs[id][cls];	/* Data table */
+	bl = HUFF_BIT + 1;
+#else
+	/* Incremental serch for all codes */
+	hb = jd->huffbits[id][cls];	/* Bit distribution table */
+	hc = jd->huffcode[id][cls];	/* Code word table */
+	hd = jd->huffdata[id][cls];	/* Data table */
+	bl = 1;
+#endif
+	for ( ; bl <= 16; bl++) {	/* Incremental search */
+		nc = *hb++;
+		if (nc) {
+			d = w >> (wbit - bl);
+			do {	/* Search the code word in this bit length */
+				if (d == *hc++) {		/* Matched? */
+					jd->dbit = wbit - bl;	/* Snip the huffman code */
+					return *hd;			/* Return the decoded data */
+				}
+				hd++;
+			} while (--nc);
+		}
+	}
+#endif
+
+	return 0 - (int)JDR_FMT1;	/* Err: code not found (may be collapted data) */
 }
 
 
@@ -244,18 +422,19 @@ static JRESULT create_huffman_tbl (	/* 0:OK, !0:Failed */
 
 static int bitext (	/* >=0: extracted data, <0: error code */
 	JDEC* jd,			/* Pointer to the decompressor object */
-	unsigned int nbit	/* Number of bits to extract (1 to 11) */
+	unsigned int nbit	/* Number of bits to extract (1 to 16) */
 )
 {
-	uint8_t msk, s, *dp;
-	unsigned int dc, v, f;
+	size_t dc = jd->dctr;
+	uint8_t *dp = jd->dptr;
+	unsigned int d, flg = 0;
 
+#if JD_FASTDECODE == 0
+	uint8_t mbit = jd->dbit;
 
-	msk = jd->dmsk; dc = jd->dctr; dp = jd->dptr;	/* Bit mask, number of data available, read ptr */
-	s = *dp; v = f = 0;
-
+	d = 0;
 	do {
-		if (!msk) {				/* Next byte? */
+		if (!mbit) {			/* Next byte? */
 			if (!dc) {			/* No input data is available, re-fill input buffer */
 				dp = jd->inbuf;	/* Top of input buffer */
 				dc = jd->infunc(jd, dp, JD_SZBUF);
@@ -264,87 +443,130 @@ static int bitext (	/* >=0: extracted data, <0: error code */
 				dp++;			/* Next data ptr */
 			}
 			dc--;				/* Decrement number of available bytes */
-			if (f) {			/* In flag sequence? */
-				f = 0;			/* Exit flag sequence */
+			if (flg) {			/* In flag sequence? */
+				flg = 0;		/* Exit flag sequence */
 				if (*dp != 0) return 0 - (int)JDR_FMT1;	/* Err: unexpected flag is detected (may be collapted data) */
-				*dp = s = 0xFF;			/* The flag is a data 0xFF */
+				*dp = 0xFF;		/* The flag is a data 0xFF */
 			} else {
-				s = *dp;				/* Get next data byte */
-				if (s == 0xFF) {		/* Is start of flag sequence? */
-					f = 1; continue;	/* Enter flag sequence */
+				if (*dp == 0xFF) {		/* Is start of flag sequence? */
+					flg = 1; continue;	/* Enter flag sequence */
 				}
 			}
-			msk = 0x80;		/* Read from MSB */
+			mbit = 0x80;		/* Read from MSB */
 		}
-		v <<= 1;	/* Get a bit */
-		if (s & msk) v++;
-		msk >>= 1;
+		d <<= 1;	/* Get a bit */
+		if (*dp & mbit) d |= 1;
+		mbit >>= 1;
 		nbit--;
 	} while (nbit);
 
-	jd->dmsk = msk; jd->dctr = dc; jd->dptr = dp;
+	jd->dbit = mbit; jd->dctr = dc; jd->dptr = dp;
+	return (int)d;
 
-	return (int)v;
+#else
+	unsigned int wbit = jd->dbit % 32;
+	uint32_t w = jd->wreg & ((1UL << wbit) - 1);
+
+
+	while (wbit < nbit) {	/* Prepare nbit bits into the working register */
+		if (jd->marker) {
+			d = 0xFF;	/* Input stream stalled, generate stuff bits */
+		} else {
+			if (!dc) {	/* Buffer empty, re-fill input buffer */
+				dp = jd->inbuf;	/* Top of input buffer */
+				dc = jd->infunc(jd, dp, JD_SZBUF);
+				if (!dc) return 0 - (int)JDR_INP;	/* Err: read error or wrong stream termination */
+			}
+			d = *dp++; dc--;
+			if (flg) {		/* In flag sequence? */
+				flg = 0;	/* Exit flag sequence */
+				if (d != 0) jd->marker = d;	/* Not an escape of 0xFF but a marker */
+				d = 0xFF;
+			} else {
+				if (d == 0xFF) {		/* Is start of flag sequence? */
+					flg = 1; continue;	/* Enter flag sequence, get trailing byte */
+				}
+			}
+		}
+		w = w << 8 | d;	/* Get 8 bits into the working register */
+		wbit += 8;
+	}
+	jd->wreg = w; jd->dbit = wbit - nbit;
+	jd->dctr = dc; jd->dptr = dp;
+
+	return (int)(w >> ((wbit - nbit) % 32));
+#endif
 }
 
 
 
 
 /*-----------------------------------------------------------------------*/
-/* Extract a huffman decoded data from input stream                      */
+/* Process restart interval                                              */
 /*-----------------------------------------------------------------------*/
 
-static int huffext (		/* >=0: decoded data, <0: error code */
-	JDEC* jd,				/* Pointer to the decompressor object */
-	const uint8_t* hbits,	/* Pointer to the bit distribution table */
-	const uint16_t* hcode,	/* Pointer to the code word table */
-	const uint8_t* hdata	/* Pointer to the data table */
+static JRESULT restart (
+	JDEC* jd,		/* Pointer to the decompressor object */
+	uint16_t rstn	/* Expected restert sequense number */
 )
 {
-	uint8_t msk, s, *dp;
-	unsigned int dc, v, f, bl, nd;
+	unsigned int i;
+	uint8_t *dp = jd->dptr;
+	size_t dc = jd->dctr;
+
+#if JD_FASTDECODE == 0
+	uint16_t d = 0;
+
+	/* Get two bytes from the input stream */
+	for (i = 0; i < 2; i++) {
+		if (!dc) {	/* No input data is available, re-fill input buffer */
+			dp = jd->inbuf;
+			dc = jd->infunc(jd, dp, JD_SZBUF);
+			if (!dc) return JDR_INP;
+		} else {
+			dp++;
+		}
+		dc--;
+		d = d << 8 | *dp;	/* Get a byte */
+	}
+	jd->dptr = dp; jd->dctr = dc; jd->dbit = 0;
+
+	/* Check the marker */
+	if ((d & 0xFFD8) != 0xFFD0 || (d & 7) != (rstn & 7)) {
+		return JDR_FMT1;	/* Err: expected RSTn marker is not detected (may be collapted data) */
+	}
+
+#else
+	uint16_t marker;
 
 
-	msk = jd->dmsk; dc = jd->dctr; dp = jd->dptr;	/* Bit mask, number of data available, read ptr */
-	s = *dp; v = f = 0;
-	bl = 16;	/* Max code length */
-	do {
-		if (!msk) {		/* Next byte? */
-			if (!dc) {	/* No input data is available, re-fill input buffer */
-				dp = jd->inbuf;	/* Top of input buffer */
+	if (jd->marker) {	/* Generate a maker if it has been detected */
+		marker = 0xFF00 | jd->marker;
+		jd->marker = 0;
+	} else {
+		marker = 0;
+		for (i = 0; i < 2; i++) {	/* Get a restart marker */
+			if (!dc) {		/* No input data is available, re-fill input buffer */
+				dp = jd->inbuf;
 				dc = jd->infunc(jd, dp, JD_SZBUF);
-				if (!dc) return 0 - (int)JDR_INP;	/* Err: read error or wrong stream termination */
-			} else {
-				dp++;	/* Next data ptr */
+				if (!dc) return JDR_INP;
 			}
-			dc--;		/* Decrement number of available bytes */
-			if (f) {		/* In flag sequence? */
-				f = 0;		/* Exit flag sequence */
-				if (*dp != 0) return 0 - (int)JDR_FMT1;	/* Err: unexpected flag is detected (may be collapted data) */
-				*dp = s = 0xFF;			/* The flag is a data 0xFF */
-			} else {
-				s = *dp;				/* Get next data byte */
-				if (s == 0xFF) {		/* Is start of flag sequence? */
-					f = 1; continue;	/* Enter flag sequence, get trailing byte */
-				}
-			}
-			msk = 0x80;		/* Read from MSB */
+			marker = (marker << 8) | *dp++;	/* Get a byte */
+			dc--;
 		}
-		v <<= 1;	/* Get a bit */
-		if (s & msk) v++;
-		msk >>= 1;
+		jd->dptr = dp; jd->dctr = dc;
+	}
 
-		for (nd = *hbits++; nd; nd--) {	/* Search the code word in this bit length */
-			if (v == *hcode++) {		/* Matched? */
-				jd->dmsk = msk; jd->dctr = dc; jd->dptr = dp;
-				return *hdata;			/* Return the decoded data */
-			}
-			hdata++;
-		}
-		bl--;
-	} while (bl);
+	/* Check the marker */
+	if ((marker & 0xFFD8) != 0xFFD0 || (marker & 7) != (rstn & 7)) {
+		return JDR_FMT1;	/* Err: expected RSTn marker was not detected (may be collapted data) */
+	}
 
-	return 0 - (int)JDR_FMT1;	/* Err: code not found (may be collapted data) */
+	jd->dbit = 0;			/* Discard stuff bits */
+#endif
+
+	jd->dcv[2] = jd->dcv[1] = jd->dcv[0] = 0;	/* Reset DC offset */
+	return JDR_OK;
 }
 
 
@@ -356,7 +578,7 @@ static int huffext (		/* >=0: decoded data, <0: error code */
 
 static void block_idct (
 	int32_t* src,	/* Input block data (de-quantized and pre-scaled for Arai Algorithm) */
-	uint8_t* dst	/* Pointer to the destination to store the block as byte array */
+	jd_yuv_t* dst	/* Pointer to the destination to store the block as byte array */
 )
 {
 	const int32_t M13 = (int32_t)(1.41421*4096), M2 = (int32_t)(1.08239*4096), M4 = (int32_t)(2.61313*4096), M5 = (int32_t)(1.84776*4096);
@@ -445,7 +667,18 @@ static void block_idct (
 		v5 -= v6;
 		v4 -= v5;
 
-		dst[0] = BYTECLIP((v0 + v7) >> 8);	/* Descale the transformed values 8 bits and output */
+		/* Descale the transformed values 8 bits and output a row */
+#if JD_FASTDECODE >= 1
+		dst[0] = (int16_t)((v0 + v7) >> 8);
+		dst[7] = (int16_t)((v0 - v7) >> 8);
+		dst[1] = (int16_t)((v1 + v6) >> 8);
+		dst[6] = (int16_t)((v1 - v6) >> 8);
+		dst[2] = (int16_t)((v2 + v5) >> 8);
+		dst[5] = (int16_t)((v2 - v5) >> 8);
+		dst[3] = (int16_t)((v3 + v4) >> 8);
+		dst[4] = (int16_t)((v3 - v4) >> 8);
+#else
+		dst[0] = BYTECLIP((v0 + v7) >> 8);
 		dst[7] = BYTECLIP((v0 - v7) >> 8);
 		dst[1] = BYTECLIP((v1 + v6) >> 8);
 		dst[6] = BYTECLIP((v1 - v6) >> 8);
@@ -453,9 +686,9 @@ static void block_idct (
 		dst[5] = BYTECLIP((v2 - v5) >> 8);
 		dst[3] = BYTECLIP((v3 + v4) >> 8);
 		dst[4] = BYTECLIP((v3 - v4) >> 8);
-		dst += 8;
+#endif
 
-		src += 8;	/* Next row */
+		dst += 8; src += 8;	/* Next row */
 	}
 }
 
@@ -463,7 +696,7 @@ static void block_idct (
 
 
 /*-----------------------------------------------------------------------*/
-/* Load all blocks in the MCU into working buffer                        */
+/* Load all blocks in an MCU into working buffer                         */
 /*-----------------------------------------------------------------------*/
 
 static JRESULT mcu_load (
@@ -471,69 +704,72 @@ static JRESULT mcu_load (
 )
 {
 	int32_t *tmp = (int32_t*)jd->workbuf;	/* Block working buffer for de-quantize and IDCT */
-	int b, d, e;
-	unsigned int blk, nby, nbc, i, z, id, cmp;
-	uint8_t *bp;
-	const uint8_t *hb, *hd;
-	const uint16_t *hc;
+	int d, e;
+	unsigned int blk, nby, i, bc, z, id, cmp;
+	jd_yuv_t *bp;
 	const int32_t *dqf;
 
 
 	nby = jd->msx * jd->msy;	/* Number of Y blocks (1, 2 or 4) */
-	nbc = 2;					/* Number of C blocks (2) */
-	bp = jd->mcubuf;			/* Pointer to the first block */
+	bp = jd->mcubuf;			/* Pointer to the first block of MCU */
 
-	for (blk = 0; blk < nby + nbc; blk++) {
+	for (blk = 0; blk < nby + 2; blk++) {	/* Get nby Y blocks and two C blocks */
 		cmp = (blk < nby) ? 0 : blk - nby + 1;	/* Component number 0:Y, 1:Cb, 2:Cr */
-		id = cmp ? 1 : 0;						/* Huffman table ID of the component */
 
-		/* Extract a DC element from input stream */
-		hb = jd->huffbits[id][0];				/* Huffman table for the DC element */
-		hc = jd->huffcode[id][0];
-		hd = jd->huffdata[id][0];
-		b = huffext(jd, hb, hc, hd);			/* Extract a huffman coded data (bit length) */
-		if (b < 0) return 0 - b;				/* Err: invalid code or input */
-		d = jd->dcv[cmp];						/* DC value of previous block */
-		if (b) {								/* If there is any difference from previous block */
-			e = bitext(jd, b);					/* Extract data bits */
-			if (e < 0) return 0 - e;			/* Err: input */
-			b = 1 << (b - 1);					/* MSB position */
-			if (!(e & b)) e -= (b << 1) - 1;	/* Restore sign if needed */
-			d += e;								/* Get current value */
-			jd->dcv[cmp] = (int16_t)d;			/* Save current DC value for next block */
-		}
-		dqf = jd->qttbl[jd->qtid[cmp]];			/* De-quantizer table ID for this component */
-		tmp[0] = d * dqf[0] >> 8;				/* De-quantize, apply scale factor of Arai algorithm and descale 8 bits */
+		if (cmp && jd->ncomp != 3) {		/* Clear C blocks if not exist (monochrome image) */
+			for (i = 0; i < 64; bp[i++] = 128) ;
 
-		/* Extract following 63 AC elements from input stream */
-		for (i = 1; i < 64; tmp[i++] = 0) ;		/* Clear rest of elements */
-		hb = jd->huffbits[id][1];				/* Huffman table for the AC elements */
-		hc = jd->huffcode[id][1];
-		hd = jd->huffdata[id][1];
-		i = 1;					/* Top of the AC elements */
-		do {
-			b = huffext(jd, hb, hc, hd);		/* Extract a huffman coded value (zero runs and bit length) */
-			if (b == 0) break;					/* EOB? */
-			if (b < 0) return 0 - b;			/* Err: invalid code or input error */
-			z = (unsigned int)b >> 4;			/* Number of leading zero elements */
-			if (z) {
-				i += z;							/* Skip zero elements */
-				if (i >= 64) return JDR_FMT1;	/* Too long zero run */
+		} else {							/* Load Y/C blocks from input stream */
+			id = cmp ? 1 : 0;						/* Huffman table ID of this component */
+
+			/* Extract a DC element from input stream */
+			d = huffext(jd, id, 0);					/* Extract a huffman coded data (bit length) */
+			if (d < 0) return (JRESULT)(0 - d);		/* Err: invalid code or input */
+			bc = (unsigned int)d;
+			d = jd->dcv[cmp];						/* DC value of previous block */
+			if (bc) {								/* If there is any difference from previous block */
+				e = bitext(jd, bc);					/* Extract data bits */
+				if (e < 0) return (JRESULT)(0 - e);	/* Err: input */
+				bc = 1 << (bc - 1);					/* MSB position */
+				if (!(e & bc)) e -= (bc << 1) - 1;	/* Restore negative value if needed */
+				d += e;								/* Get current value */
+				jd->dcv[cmp] = (int16_t)d;			/* Save current DC value for next block */
 			}
-			if (b &= 0x0F) {					/* Bit length */
-				d = bitext(jd, b);				/* Extract data bits */
-				if (d < 0) return 0 - d;		/* Err: input device */
-				b = 1 << (b - 1);				/* MSB position */
-				if (!(d & b)) d -= (b << 1) - 1;/* Restore negative value if needed */
-				z = ZIG(i);						/* Zigzag-order to raster-order converted index */
-				tmp[z] = d * dqf[z] >> 8;		/* De-quantize, apply scale factor of Arai algorithm and descale 8 bits */
-			}
-		} while (++i < 64);		/* Next AC element */
+			dqf = jd->qttbl[jd->qtid[cmp]];			/* De-quantizer table ID for this component */
+			tmp[0] = d * dqf[0] >> 8;				/* De-quantize, apply scale factor of Arai algorithm and descale 8 bits */
 
-		if (JD_USE_SCALE && jd->scale == 3) {
-			*bp = (uint8_t)((*tmp / 256) + 128);	/* If scale ratio is 1/8, IDCT can be ommited and only DC element is used */
-		} else {
-			block_idct(tmp, bp);		/* Apply IDCT and store the block to the MCU buffer */
+			/* Extract following 63 AC elements from input stream */
+			memset(&tmp[1], 0, 63 * sizeof (int32_t));	/* Initialize all AC elements */
+			z = 1;		/* Top of the AC elements (in zigzag-order) */
+			do {
+				d = huffext(jd, id, 1);				/* Extract a huffman coded value (zero runs and bit length) */
+				if (d == 0) break;					/* EOB? */
+				if (d < 0) return (JRESULT)(0 - d);	/* Err: invalid code or input error */
+				bc = (unsigned int)d;
+				z += bc >> 4;						/* Skip leading zero run */
+				if (z >= 64) return JDR_FMT1;		/* Too long zero run */
+				if (bc &= 0x0F) {					/* Bit length? */
+					d = bitext(jd, bc);				/* Extract data bits */
+					if (d < 0) return (JRESULT)(0 - d);	/* Err: input device */
+					bc = 1 << (bc - 1);				/* MSB position */
+					if (!(d & bc)) d -= (bc << 1) - 1;	/* Restore negative value if needed */
+					i = Zig[z];						/* Get raster-order index */
+					tmp[i] = d * dqf[i] >> 8;		/* De-quantize, apply scale factor of Arai algorithm and descale 8 bits */
+				}
+			} while (++z < 64);		/* Next AC element */
+
+			if (JD_FORMAT != 2 || !cmp) {	/* C components may not be processed if in grayscale output */
+				if (z == 1 || (JD_USE_SCALE && jd->scale == 3)) {	/* If no AC element or scale ratio is 1/8, IDCT can be ommited and the block is filled with DC value */
+					d = (jd_yuv_t)((*tmp / 256) + 128);
+					if (JD_FASTDECODE >= 1) {
+						for (i = 0; i < 64; bp[i++] = d) ;
+					} else {
+						memset(bp, d, 64);
+					}
+				} else {
+					block_idct(tmp, bp);	/* Apply IDCT and store the block to the MCU buffer */
+				}
+			}
 		}
 
 		bp += 64;				/* Next block */
@@ -552,19 +788,20 @@ static JRESULT mcu_load (
 static JRESULT mcu_output (
 	JDEC* jd,			/* Pointer to the decompressor object */
 	int (*outfunc)(JDEC*, void*, JRECT*),	/* RGB output function */
-	unsigned int x,		/* MCU position in the image (left of the MCU) */
-	unsigned int y		/* MCU position in the image (top of the MCU) */
+	unsigned int x,		/* MCU location in the image */
+	unsigned int y		/* MCU location in the image */
 )
 {
 	const int CVACC = (sizeof (int) > 2) ? 1024 : 128;	/* Adaptive accuracy for both 16-/32-bit systems */
 	unsigned int ix, iy, mx, my, rx, ry;
 	int yy, cb, cr;
-	uint8_t *py, *pc, *rgb24;
+	jd_yuv_t *py, *pc;
+	uint8_t *pix;
 	JRECT rect;
 
 
 	mx = jd->msx * 8; my = jd->msy * 8;					/* MCU size (pixel) */
-	rx = (x + mx <= jd->width) ? mx : jd->width - x;	/* Output rectangular size (it may be clipped at right/bottom end) */
+	rx = (x + mx <= jd->width) ? mx : jd->width - x;	/* Output rectangular size (it may be clipped at right/bottom end of image) */
 	ry = (y + my <= jd->height) ? my : jd->height - y;
 	if (JD_USE_SCALE) {
 		rx >>= jd->scale; ry >>= jd->scale;
@@ -576,33 +813,45 @@ static JRESULT mcu_output (
 
 
 	if (!JD_USE_SCALE || jd->scale != 3) {	/* Not for 1/8 scaling */
+		pix = (uint8_t*)jd->workbuf;
 
-		/* Build an RGB MCU from discrete comopnents */
-		rgb24 = (uint8_t*)jd->workbuf;
-		for (iy = 0; iy < my; iy++) {
-			pc = jd->mcubuf;
-			py = pc + iy * 8;
-			if (my == 16) {		/* Double block height? */
-				pc += 64 * 4 + (iy >> 1) * 8;
-				if (iy >= 8) py += 64;
-			} else {			/* Single block height */
-				pc += mx * 8 + iy * 8;
-			}
-			for (ix = 0; ix < mx; ix++) {
-				cb = pc[0] - 128; 	/* Get Cb/Cr component and restore right level */
-				cr = pc[64] - 128;
-				if (mx == 16) {					/* Double block width? */
-					if (ix == 8) py += 64 - 8;	/* Jump to next block if double block heigt */
-					pc += ix & 1;				/* Increase chroma pointer every two pixels */
-				} else {						/* Single block width */
-					pc++;						/* Increase chroma pointer every pixel */
+		if (JD_FORMAT != 2) {	/* RGB output (build an RGB MCU from Y/C component) */
+			for (iy = 0; iy < my; iy++) {
+				pc = py = jd->mcubuf;
+				if (my == 16) {		/* Double block height? */
+					pc += 64 * 4 + (iy >> 1) * 8;
+					if (iy >= 8) py += 64;
+				} else {			/* Single block height */
+					pc += mx * 8 + iy * 8;
 				}
-				yy = *py++;			/* Get Y component */
-
-				/* Convert YCbCr to RGB */
-				*rgb24++ = /* R */ BYTECLIP(yy + ((int)(1.402 * CVACC) * cr) / CVACC);
-				*rgb24++ = /* G */ BYTECLIP(yy - ((int)(0.344 * CVACC) * cb + (int)(0.714 * CVACC) * cr) / CVACC);
-				*rgb24++ = /* B */ BYTECLIP(yy + ((int)(1.772 * CVACC) * cb) / CVACC);
+				py += iy * 8;
+				for (ix = 0; ix < mx; ix++) {
+					cb = pc[0] - 128; 	/* Get Cb/Cr component and remove offset */
+					cr = pc[64] - 128;
+					if (mx == 16) {					/* Double block width? */
+						if (ix == 8) py += 64 - 8;	/* Jump to next block if double block heigt */
+						pc += ix & 1;				/* Step forward chroma pointer every two pixels */
+					} else {						/* Single block width */
+						pc++;						/* Step forward chroma pointer every pixel */
+					}
+					yy = *py++;			/* Get Y component */
+					*pix++ = /*R*/ BYTECLIP(yy + ((int)(1.402 * CVACC) * cr) / CVACC);
+					*pix++ = /*G*/ BYTECLIP(yy - ((int)(0.344 * CVACC) * cb + (int)(0.714 * CVACC) * cr) / CVACC);
+					*pix++ = /*B*/ BYTECLIP(yy + ((int)(1.772 * CVACC) * cb) / CVACC);
+				}
+			}
+		} else {	/* Monochrome output (build a grayscale MCU from Y comopnent) */
+			for (iy = 0; iy < my; iy++) {
+				py = jd->mcubuf + iy * 8;
+				if (my == 16) {		/* Double block height? */
+					if (iy >= 8) py += 64;
+				}
+				for (ix = 0; ix < mx; ix++) {
+					if (mx == 16) {					/* Double block width? */
+						if (ix == 8) py += 64 - 8;	/* Jump to next block if double block height */
+					}
+					*pix++ = (uint8_t)*py++;			/* Get and store a Y value as grayscale */
+				}
 			}
 		}
 
@@ -612,25 +861,29 @@ static JRESULT mcu_output (
 			uint8_t *op;
 
 			/* Get averaged RGB value of each square correcponds to a pixel */
-			s = jd->scale * 2;	/* Bumber of shifts for averaging */
+			s = jd->scale * 2;	/* Number of shifts for averaging */
 			w = 1 << jd->scale;	/* Width of square */
-			a = (mx - w) * 3;	/* Bytes to skip for next line in the square */
+			a = (mx - w) * (JD_FORMAT != 2 ? 3 : 1);	/* Bytes to skip for next line in the square */
 			op = (uint8_t*)jd->workbuf;
 			for (iy = 0; iy < my; iy += w) {
 				for (ix = 0; ix < mx; ix += w) {
-					rgb24 = (uint8_t*)jd->workbuf + (iy * mx + ix) * 3;
+					pix = (uint8_t*)jd->workbuf + (iy * mx + ix) * (JD_FORMAT != 2 ? 3 : 1);
 					r = g = b = 0;
 					for (y = 0; y < w; y++) {	/* Accumulate RGB value in the square */
 						for (x = 0; x < w; x++) {
-							r += *rgb24++;
-							g += *rgb24++;
-							b += *rgb24++;
+							r += *pix++;	/* Accumulate R or Y (monochrome output) */
+							if (JD_FORMAT != 2) {	/* RGB output? */
+								g += *pix++;	/* Accumulate G */
+								b += *pix++;	/* Accumulate B */
+							}
 						}
-						rgb24 += a;
-					}							/* Put the averaged RGB value as a pixel */
-					*op++ = (uint8_t)(r >> s);
-					*op++ = (uint8_t)(g >> s);
-					*op++ = (uint8_t)(b >> s);
+						pix += a;
+					}							/* Put the averaged pixel value */
+					*op++ = (uint8_t)(r >> s);	/* Put R or Y (monochrome output) */
+					if (JD_FORMAT != 2) {	/* RGB output? */
+						*op++ = (uint8_t)(g >> s);	/* Put G */
+						*op++ = (uint8_t)(b >> s);	/* Put B */
+					}
 				}
 			}
 		}
@@ -638,7 +891,7 @@ static JRESULT mcu_output (
 	} else {	/* For only 1/8 scaling (left-top pixel in each block are the DC value of the block) */
 
 		/* Build a 1/8 descaled RGB MCU from discrete comopnents */
-		rgb24 = (uint8_t*)jd->workbuf;
+		pix = (uint8_t*)jd->workbuf;
 		pc = jd->mcubuf + mx * my;
 		cb = pc[0] - 128;		/* Get Cb/Cr component and restore right level */
 		cr = pc[64] - 128;
@@ -648,18 +901,20 @@ static JRESULT mcu_output (
 			for (ix = 0; ix < mx; ix += 8) {
 				yy = *py;	/* Get Y component */
 				py += 64;
-
-				/* Convert YCbCr to RGB */
-				*rgb24++ = /* R */ BYTECLIP(yy + ((int)(1.402 * CVACC) * cr / CVACC));
-				*rgb24++ = /* G */ BYTECLIP(yy - ((int)(0.344 * CVACC) * cb + (int)(0.714 * CVACC) * cr) / CVACC);
-				*rgb24++ = /* B */ BYTECLIP(yy + ((int)(1.772 * CVACC) * cb / CVACC));
+				if (JD_FORMAT != 2) {
+					*pix++ = /*R*/ BYTECLIP(yy + ((int)(1.402 * CVACC) * cr / CVACC));
+					*pix++ = /*G*/ BYTECLIP(yy - ((int)(0.344 * CVACC) * cb + (int)(0.714 * CVACC) * cr) / CVACC);
+					*pix++ = /*B*/ BYTECLIP(yy + ((int)(1.772 * CVACC) * cb / CVACC));
+				} else {
+					*pix++ = yy;
+				}
 			}
 		}
 	}
 
 	/* Squeeze up pixel table if a part of MCU is to be truncated */
 	mx >>= jd->scale;
-	if (rx < mx) {
+	if (rx < mx) {	/* Is the MCU spans rigit edge? */
 		uint8_t *s, *d;
 		unsigned int x, y;
 
@@ -667,10 +922,12 @@ static JRESULT mcu_output (
 		for (y = 0; y < ry; y++) {
 			for (x = 0; x < rx; x++) {	/* Copy effective pixels */
 				*d++ = *s++;
-				*d++ = *s++;
-				*d++ = *s++;
+				if (JD_FORMAT != 2) {
+					*d++ = *s++;
+					*d++ = *s++;
+				}
 			}
-			s += (mx - rx) * 3;	/* Skip truncated pixels */
+			s += (mx - rx) * (JD_FORMAT != 2 ? 3 : 1);	/* Skip truncated pixels */
 		}
 	}
 
@@ -688,52 +945,8 @@ static JRESULT mcu_output (
 		} while (--n);
 	}
 
-	/* Output the RGB rectangular */
-	return outfunc(jd, jd->workbuf, &rect) ? JDR_OK : JDR_INTR;
-}
-
-
-
-
-/*-----------------------------------------------------------------------*/
-/* Process restart interval                                              */
-/*-----------------------------------------------------------------------*/
-
-static JRESULT restart (
-	JDEC* jd,		/* Pointer to the decompressor object */
-	uint16_t rstn	/* Expected restert sequense number */
-)
-{
-	unsigned int i, dc;
-	uint16_t d;
-	uint8_t *dp;
-
-
-	/* Discard padding bits and get two bytes from the input stream */
-	dp = jd->dptr; dc = jd->dctr;
-	d = 0;
-	for (i = 0; i < 2; i++) {
-		if (!dc) {	/* No input data is available, re-fill input buffer */
-			dp = jd->inbuf;
-			dc = jd->infunc(jd, dp, JD_SZBUF);
-			if (!dc) return JDR_INP;
-		} else {
-			dp++;
-		}
-		dc--;
-		d = (d << 8) | *dp;	/* Get a byte */
-	}
-	jd->dptr = dp; jd->dctr = dc; jd->dmsk = 0;
-
-	/* Check the marker */
-	if ((d & 0xFFD8) != 0xFFD0 || (d & 7) != (rstn & 7)) {
-		return JDR_FMT1;	/* Err: expected RSTn marker is not detected (may be collapted data) */
-	}
-
-	/* Reset DC offset */
-	jd->dcv[2] = jd->dcv[1] = jd->dcv[0] = 0;
-
-	return JDR_OK;
+	/* Output the rectangular */
+	return outfunc(jd, jd->workbuf, &rect) ? JDR_OK : JDR_INTR; 
 }
 
 
@@ -748,123 +961,106 @@ static JRESULT restart (
 
 JRESULT jd_prepare (
 	JDEC* jd,				/* Blank decompressor object */
-	unsigned int (*infunc)(JDEC*, uint8_t*, unsigned int),	/* JPEG strem input function */
+	size_t (*infunc)(JDEC*, uint8_t*, size_t),	/* JPEG strem input function */
 	void* pool,				/* Working buffer for the decompression session */
-	unsigned int sz_pool,	/* Size of working buffer */
+	size_t sz_pool,			/* Size of working buffer */
 	void* dev				/* I/O device identifier for the session */
 )
 {
 	uint8_t *seg, b;
 	uint16_t marker;
-	uint32_t ofs;
-	unsigned int n, i, j, len;
+	unsigned int n, i, ofs;
+	size_t len;
 	JRESULT rc;
 
 
-	if (!pool) return JDR_PAR;
-
+	memset(jd, 0, sizeof (JDEC));	/* Clear decompression object (this might be a problem if machine's null pointer is not all bits zero) */
 	jd->pool = pool;		/* Work memroy */
 	jd->sz_pool = sz_pool;	/* Size of given work memory */
 	jd->infunc = infunc;	/* Stream input function */
 	jd->device = dev;		/* I/O device identifier */
-	jd->nrst = 0;			/* No restart interval (default) */
-
-	for (i = 0; i < 2; i++) {	/* Nulls pointers */
-		for (j = 0; j < 2; j++) {
-			jd->huffbits[i][j] = 0;
-			jd->huffcode[i][j] = 0;
-			jd->huffdata[i][j] = 0;
-		}
-	}
-	for (i = 0; i < 4; jd->qttbl[i++] = 0) ;
 
 	jd->inbuf = seg = alloc_pool(jd, JD_SZBUF);		/* Allocate stream input buffer */
 	if (!seg) return JDR_MEM1;
 
-	if (jd->infunc(jd, seg, 2) != 2) return JDR_INP;/* Check SOI marker */
-	if (LDB_WORD(seg) != 0xFFD8) return JDR_FMT1;	/* Err: SOI is not detected */
-	ofs = 2;
+	ofs = marker = 0;		/* Find SOI marker */
+	do {
+		if (jd->infunc(jd, seg, 1) != 1) return JDR_INP;	/* Err: SOI was not detected */
+		ofs++;
+		marker = marker << 8 | seg[0];
+	} while (marker != 0xFFD8);
 
-	for (;;) {
+	for (;;) {				/* Parse JPEG segments */
 		/* Get a JPEG marker */
 		if (jd->infunc(jd, seg, 4) != 4) return JDR_INP;
 		marker = LDB_WORD(seg);		/* Marker */
 		len = LDB_WORD(seg + 2);	/* Length field */
 		if (len <= 2 || (marker >> 8) != 0xFF) return JDR_FMT1;
-		len -= 2;		/* Content size excluding length field */
-		ofs += 4 + len;	/* Number of bytes loaded */
+		len -= 2;			/* Segent content size */
+		ofs += 4 + len;		/* Number of bytes loaded */
 
 		switch (marker & 0xFF) {
 		case 0xC0:	/* SOF0 (baseline JPEG) */
-			/* Load segment data */
 			if (len > JD_SZBUF) return JDR_MEM2;
-			if (jd->infunc(jd, seg, len) != len) return JDR_INP;
+			if (jd->infunc(jd, seg, len) != len) return JDR_INP;	/* Load segment data */
 
-			jd->width = LDB_WORD(seg+3);		/* Image width in unit of pixel */
-			jd->height = LDB_WORD(seg+1);		/* Image height in unit of pixel */
-			if (seg[5] != 3) return JDR_FMT3;	/* Err: Supports only Y/Cb/Cr format */
+			jd->width = LDB_WORD(&seg[3]);		/* Image width in unit of pixel */
+			jd->height = LDB_WORD(&seg[1]);		/* Image height in unit of pixel */
+			jd->ncomp = seg[5];					/* Number of color components */
+			if (jd->ncomp != 3 && jd->ncomp != 1) return JDR_FMT3;	/* Err: Supports only Grayscale and Y/Cb/Cr */
 
-			/* Check three image components */
-			for (i = 0; i < 3; i++) {
+			/* Check each image component */
+			for (i = 0; i < jd->ncomp; i++) {
 				b = seg[7 + 3 * i];							/* Get sampling factor */
-				if (!i) {	/* Y component */
+				if (i == 0) {	/* Y component */
 					if (b != 0x11 && b != 0x22 && b != 0x21) {	/* Check sampling factor */
 						return JDR_FMT3;					/* Err: Supports only 4:4:4, 4:2:0 or 4:2:2 */
 					}
 					jd->msx = b >> 4; jd->msy = b & 15;		/* Size of MCU [blocks] */
-				} else {	/* Cb/Cr component */
-					if (b != 0x11) return JDR_FMT3;			/* Err: Sampling factor of Cr/Cb must be 1 */
+				} else {		/* Cb/Cr component */
+					if (b != 0x11) return JDR_FMT3;			/* Err: Sampling factor of Cb/Cr must be 1 */
 				}
-				b = seg[8 + 3 * i];							/* Get dequantizer table ID for this component */
-				if (b > 3) return JDR_FMT3;					/* Err: Invalid ID */
-				jd->qtid[i] = b;
+				jd->qtid[i] = seg[8 + 3 * i];				/* Get dequantizer table ID for this component */
+				if (jd->qtid[i] > 3) return JDR_FMT3;		/* Err: Invalid ID */
 			}
 			break;
 
-		case 0xDD:	/* DRI */
-			/* Load segment data */
+		case 0xDD:	/* DRI - Define Restart Interval */
 			if (len > JD_SZBUF) return JDR_MEM2;
-			if (jd->infunc(jd, seg, len) != len) return JDR_INP;
+			if (jd->infunc(jd, seg, len) != len) return JDR_INP;	/* Load segment data */
 
-			/* Get restart interval (MCUs) */
-			jd->nrst = LDB_WORD(seg);
+			jd->nrst = LDB_WORD(seg);	/* Get restart interval (MCUs) */
 			break;
 
-		case 0xC4:	/* DHT */
-			/* Load segment data */
+		case 0xC4:	/* DHT - Define Huffman Tables */
 			if (len > JD_SZBUF) return JDR_MEM2;
-			if (jd->infunc(jd, seg, len) != len) return JDR_INP;
+			if (jd->infunc(jd, seg, len) != len) return JDR_INP;	/* Load segment data */
 
-			/* Create huffman tables */
-			rc = create_huffman_tbl(jd, seg, len);
+			rc = create_huffman_tbl(jd, seg, len);	/* Create huffman tables */
 			if (rc) return rc;
 			break;
 
-		case 0xDB:	/* DQT */
-			/* Load segment data */
+		case 0xDB:	/* DQT - Define Quaitizer Tables */
 			if (len > JD_SZBUF) return JDR_MEM2;
-			if (jd->infunc(jd, seg, len) != len) return JDR_INP;
+			if (jd->infunc(jd, seg, len) != len) return JDR_INP;	/* Load segment data */
 
-			/* Create de-quantizer tables */
-			rc = create_qt_tbl(jd, seg, len);
+			rc = create_qt_tbl(jd, seg, len);	/* Create de-quantizer tables */
 			if (rc) return rc;
 			break;
 
-		case 0xDA:	/* SOS */
-			/* Load segment data */
+		case 0xDA:	/* SOS - Start of Scan */
 			if (len > JD_SZBUF) return JDR_MEM2;
-			if (jd->infunc(jd, seg, len) != len) return JDR_INP;
+			if (jd->infunc(jd, seg, len) != len) return JDR_INP;	/* Load segment data */
 
 			if (!jd->width || !jd->height) return JDR_FMT1;	/* Err: Invalid image size */
-
-			if (seg[0] != 3) return JDR_FMT3;				/* Err: Supports only three color components format */
+			if (seg[0] != jd->ncomp) return JDR_FMT3;		/* Err: Wrong color components */
 
 			/* Check if all tables corresponding to each components have been loaded */
-			for (i = 0; i < 3; i++) {
+			for (i = 0; i < jd->ncomp; i++) {
 				b = seg[2 + 2 * i];	/* Get huffman table ID */
 				if (b != 0x00 && b != 0x11)	return JDR_FMT3;	/* Err: Different table number for DC/AC element */
-				b = i ? 1 : 0;
-				if (!jd->huffbits[b][0] || !jd->huffbits[b][1]) {	/* Check dc/ac huffman table for this component */
+				n = i ? 1 : 0;							/* Component class */
+				if (!jd->huffbits[n][0] || !jd->huffbits[n][1]) {	/* Check huffman table for this component */
 					return JDR_FMT1;					/* Err: Nnot loaded */
 				}
 				if (!jd->qttbl[jd->qtid[i]]) {			/* Check dequantizer table for this component */
@@ -872,22 +1068,21 @@ JRESULT jd_prepare (
 				}
 			}
 
-			/* Allocate working buffer for MCU and RGB */
+			/* Allocate working buffer for MCU and pixel output */
 			n = jd->msy * jd->msx;						/* Number of Y blocks in the MCU */
 			if (!n) return JDR_FMT1;					/* Err: SOF0 has not been loaded */
 			len = n * 64 * 2 + 64;						/* Allocate buffer for IDCT and RGB output */
 			if (len < 256) len = 256;					/* but at least 256 byte is required for IDCT */
 			jd->workbuf = alloc_pool(jd, len);			/* and it may occupy a part of following MCU working buffer for RGB output */
 			if (!jd->workbuf) return JDR_MEM1;			/* Err: not enough memory */
-			jd->mcubuf = (uint8_t*)alloc_pool(jd, (unsigned int)((n + 2) * 64));	/* Allocate MCU working buffer */
+			jd->mcubuf = alloc_pool(jd, (n + 2) * 64 * sizeof (jd_yuv_t));	/* Allocate MCU working buffer */
 			if (!jd->mcubuf) return JDR_MEM1;			/* Err: not enough memory */
 
-			/* Pre-load the JPEG data to extract it from the bit stream */
-			jd->dptr = seg; jd->dctr = 0; jd->dmsk = 0;	/* Prepare to read bit stream */
-			if (ofs %= JD_SZBUF) {						/* Align read offset to JD_SZBUF */
-				jd->dctr = jd->infunc(jd, seg + ofs, (unsigned int)(JD_SZBUF - ofs));
-				jd->dptr = seg + ofs - 1;
+			/* Align stream read offset to JD_SZBUF */
+			if (ofs %= JD_SZBUF) {
+				jd->dctr = jd->infunc(jd, seg + ofs, (size_t)(JD_SZBUF - ofs));
 			}
+			jd->dptr = seg + ofs - (JD_FASTDECODE ? 0 : 1);
 
 			return JDR_OK;		/* Initialization succeeded. Ready to decompress the JPEG image. */
 
@@ -907,10 +1102,8 @@ JRESULT jd_prepare (
 			return JDR_FMT3;	/* Unsuppoted JPEG standard (may be progressive JPEG) */
 
 		default:	/* Unknown segment (comment, exif or etc..) */
-			/* Skip segment data */
-			if (jd->infunc(jd, 0, len) != len) {	/* Null pointer specifies to skip bytes of stream */
-				return JDR_INP;
-			}
+			/* Skip segment data (null pointer specifies to remove data from the stream) */
+			if (jd->infunc(jd, 0, len) != len) return JDR_INP;
 		}
 	}
 }
@@ -949,15 +1142,12 @@ JRESULT jd_decomp (
 				if (rc != JDR_OK) return rc;
 				rst = 1;
 			}
-			rc = mcu_load(jd);					/* Load an MCU (decompress huffman coded stream and apply IDCT) */
+			rc = mcu_load(jd);					/* Load an MCU (decompress huffman coded stream, dequantize and apply IDCT) */
 			if (rc != JDR_OK) return rc;
-			rc = mcu_output(jd, outfunc, x, y);	/* Output the MCU (color space conversion, scaling and output) */
+			rc = mcu_output(jd, outfunc, x, y);	/* Output the MCU (YCbCr to RGB, scaling and output) */
 			if (rc != JDR_OK) return rc;
 		}
 	}
 
 	return rc;
 }
-
-
-

--- a/tjpgd.h
+++ b/tjpgd.h
@@ -1,50 +1,54 @@
 /*----------------------------------------------------------------------------/
-/ TJpgDec - Tiny JPEG Decompressor include file               (C)ChaN, 2020
+/ TJpgDec - Tiny JPEG Decompressor R0.03 include file         (C)ChaN, 2021
 /----------------------------------------------------------------------------*/
 #ifndef DEF_TJPGDEC
 #define DEF_TJPGDEC
-/*---------------------------------------------------------------------------*/
-/* System Configurations */
-
-#define	JD_SZBUF		512	/* Size of stream input buffer */
-#define JD_FORMAT		0	/* Output pixel format 0:RGB888 (3 BYTE/pix), 1:RGB565 (1 WORD/pix) */
-#define	JD_USE_SCALE	1	/* Use descaling feature for output */
-#define JD_TBLCLIP		1	/* Use table for saturation (might be a bit faster but increases 1K bytes of code size) */
-
-/*---------------------------------------------------------------------------*/
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#if defined(___WIN32)	/* Main development platform */
+#include "tjpgdcnf.h"
+#include <string.h>
+
+#if defined(_WIN32)	/* VC++ or some compiler without stdint.h */
 typedef unsigned char	uint8_t;
 typedef unsigned short	uint16_t;
 typedef short			int16_t;
 typedef unsigned long	uint32_t;
 typedef long			int32_t;
-#else
-#include "stdint.h"
+#else				/* Embedded platform */
+#include <stdint.h>
 #endif
+
+#if JD_FASTDECODE >= 1
+typedef int16_t jd_yuv_t;
+#else
+typedef uint8_t jd_yuv_t;
+#endif
+
 
 /* Error code */
 typedef enum {
 	JDR_OK = 0,	/* 0: Succeeded */
-	JDR_INTR,	/* 1: Interrupted by output function */
+	JDR_INTR,	/* 1: Interrupted by output function */	
 	JDR_INP,	/* 2: Device error or wrong termination of input stream */
 	JDR_MEM1,	/* 3: Insufficient memory pool for the image */
 	JDR_MEM2,	/* 4: Insufficient stream input buffer */
 	JDR_PAR,	/* 5: Parameter error */
-	JDR_FMT1,	/* 6: Data format error (may be damaged data) */
+	JDR_FMT1,	/* 6: Data format error (may be broken data) */
 	JDR_FMT2,	/* 7: Right format but not supported */
 	JDR_FMT3	/* 8: Not supported JPEG standard */
 } JRESULT;
 
 
 
-/* Rectangular structure */
+/* Rectangular region in the output image */
 typedef struct {
-	uint16_t left, right, top, bottom;
+	uint16_t left;		/* Left end */
+	uint16_t right;		/* Right end */
+	uint16_t top;		/* Top end */
+	uint16_t bottom;	/* Bottom end */
 } JRECT;
 
 
@@ -52,13 +56,14 @@ typedef struct {
 /* Decompressor object structure */
 typedef struct JDEC JDEC;
 struct JDEC {
-	unsigned int dctr;			/* Number of bytes available in the input buffer */
+	size_t dctr;				/* Number of bytes available in the input buffer */
 	uint8_t* dptr;				/* Current data read ptr */
 	uint8_t* inbuf;				/* Bit stream input buffer */
-	uint8_t dmsk;				/* Current bit in the current read byte */
+	uint8_t dbit;				/* Number of bits availavble in wreg or reading bit mask */
 	uint8_t scale;				/* Output scaling ratio */
 	uint8_t msx, msy;			/* MCU size in unit of block (width, height) */
-	uint8_t qtid[3];			/* Quantization table ID of each component */
+	uint8_t qtid[3];			/* Quantization table ID of each component, Y, Cb, Cr */
+	uint8_t ncomp;				/* Number of color components 1:grayscale, 3:color */
 	int16_t dcv[3];				/* Previous DC element of each component */
 	uint16_t nrst;				/* Restart inverval */
 	uint16_t width, height;		/* Size of the input image (pixel) */
@@ -66,18 +71,27 @@ struct JDEC {
 	uint16_t* huffcode[2][2];	/* Huffman code word tables [id][dcac] */
 	uint8_t* huffdata[2][2];	/* Huffman decoded data tables [id][dcac] */
 	int32_t* qttbl[4];			/* Dequantizer tables [id] */
+#if JD_FASTDECODE >= 1
+	uint32_t wreg;				/* Working shift register */
+	uint8_t marker;				/* Detected marker (0:None) */
+#if JD_FASTDECODE == 2
+	uint8_t longofs[2][2];		/* Table offset of long code [id][dcac] */
+	uint16_t* hufflut_ac[2];	/* Fast huffman decode tables for AC short code [id] */
+	uint8_t* hufflut_dc[2];		/* Fast huffman decode tables for DC short code [id] */
+#endif
+#endif
 	void* workbuf;				/* Working buffer for IDCT and RGB output */
-	uint8_t* mcubuf;			/* Working buffer for the MCU */
+	jd_yuv_t* mcubuf;			/* Working buffer for the MCU */
 	void* pool;					/* Pointer to available memory pool */
-	unsigned int sz_pool;		/* Size of momory pool (bytes available) */
-	unsigned int (*infunc)(JDEC*, uint8_t*, unsigned int);	/* Pointer to jpeg stream input function */
+	size_t sz_pool;				/* Size of momory pool (bytes available) */
+	size_t (*infunc)(JDEC*, uint8_t*, size_t);	/* Pointer to jpeg stream input function */
 	void* device;				/* Pointer to I/O device identifiler for the session */
 };
 
 
 
 /* TJpgDec API functions */
-JRESULT jd_prepare (JDEC* jd, unsigned int (*infunc)(JDEC*,uint8_t*,unsigned int), void* pool, unsigned int sz_pool, void* dev);
+JRESULT jd_prepare (JDEC* jd, size_t (*infunc)(JDEC*,uint8_t*,size_t), void* pool, size_t sz_pool, void* dev);
 JRESULT jd_decomp (JDEC* jd, int (*outfunc)(JDEC*,void*,JRECT*), uint8_t scale);
 
 

--- a/tjpgdcnf.h
+++ b/tjpgdcnf.h
@@ -1,0 +1,33 @@
+/*----------------------------------------------*/
+/* TJpgDec System Configurations R0.03          */
+/*----------------------------------------------*/
+
+#define	JD_SZBUF		512
+/* Specifies size of stream input buffer */
+
+#define JD_FORMAT		0
+/* Specifies output pixel format.
+/  0: RGB888 (24-bit/pix)
+/  1: RGB565 (16-bit/pix)
+/  2: Grayscale (8-bit/pix)
+*/
+
+#define	JD_USE_SCALE	1
+/* Switches output descaling feature.
+/  0: Disable
+/  1: Enable
+*/
+
+#define JD_TBLCLIP		1
+/* Use table conversion for saturation arithmetic. A bit faster, but increases 1 KB of code size.
+/  0: Disable
+/  1: Enable
+*/
+
+#define JD_FASTDECODE	0
+/* Optimization level
+/  0: Basic optimization. Suitable for 8/16-bit MCUs.
+/  1: + 32-bit barrel shifter. Suitable for 32-bit MCUs.
+/  2: + Table conversion for huffman decoding (wants 6 << HUFF_BIT bytes of RAM)
+*/
+


### PR DESCRIPTION
Upgrade the JPEG decoder (TJpgDec) from R0.01d to R0.03 released
July 1, 2021.

This is a copy of TJpgDec downloaded from the authoritative site:
http://elm-chan.org/fsw/tjpgd/00index.html.

This fixes https://github.com/lvgl/lv_lib_split_jpg/issues/16