### PR TITLE
Directly invoke cmake for pull_request action.

### DIFF
--- a/.github/workflows/pr_audit.yml
+++ b/.github/workflows/pr_audit.yml
@@ -22,13 +22,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      buildDir: '${{ github.workspace }}/build'
+      CMAKE_BUILD_DIR: ${{ github.workspace }}/build/
+      CMAKE_BUILD_TYPE: Debug
     steps:
     - name: Get source
       uses: actions/checkout@v2
       with:
         submodules: recursive
-    - name: Build
-      uses: lukka/run-cmake@v3
-      with:
-        buildDirectory: ${{ env.buildDir }}
+    - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.9
+        with:
+          cmake-version: '3.16.x'
+    - name: Install dependencies and generate project files
+        run: |
+          cmake -S "${{ github.workspace }}" -B "${{ env.CMAKE_BUILD_DIR }}"
+          -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCONFIG_LV_CONF_SKIP=1
+      - name: Build
+        run: |
+          cmake --build "${{ env.CMAKE_BUILD_DIR }}"

--- a/.github/workflows/pr_audit.yml
+++ b/.github/workflows/pr_audit.yml
@@ -35,8 +35,7 @@ jobs:
         cmake-version: '3.16.x'
     - name: Install dependencies and generate project files
       run: |
-        cmake -S "${{ github.workspace }}" -B "${{ env.CMAKE_BUILD_DIR }}"
-        -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCONFIG_LV_CONF_SKIP=1
+        cmake -S "${{ github.workspace }}" -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCONFIG_LV_CONF_SKIP=1
     - name: Build
       run: |
         cmake --build "${{ env.CMAKE_BUILD_DIR }}"

--- a/.github/workflows/pr_audit.yml
+++ b/.github/workflows/pr_audit.yml
@@ -30,13 +30,13 @@ jobs:
       with:
         submodules: recursive
     - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.9
-        with:
-          cmake-version: '3.16.x'
+      uses: jwlawson/actions-setup-cmake@v1.9
+      with:
+        cmake-version: '3.16.x'
     - name: Install dependencies and generate project files
-        run: |
-          cmake -S "${{ github.workspace }}" -B "${{ env.CMAKE_BUILD_DIR }}"
-          -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCONFIG_LV_CONF_SKIP=1
+      run: |
+        cmake -S "${{ github.workspace }}" -B "${{ env.CMAKE_BUILD_DIR }}"
+        -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCONFIG_LV_CONF_SKIP=1
     - name: Build
-        run: |
-          cmake --build "${{ env.CMAKE_BUILD_DIR }}"
+      run: |
+        cmake --build "${{ env.CMAKE_BUILD_DIR }}"

--- a/.github/workflows/pr_audit.yml
+++ b/.github/workflows/pr_audit.yml
@@ -37,6 +37,6 @@ jobs:
         run: |
           cmake -S "${{ github.workspace }}" -B "${{ env.CMAKE_BUILD_DIR }}"
           -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCONFIG_LV_CONF_SKIP=1
-      - name: Build
+    - name: Build
         run: |
           cmake --build "${{ env.CMAKE_BUILD_DIR }}"


### PR DESCRIPTION
jwlawson/actions-setup-cmake@v1.9 ignores the cmake ExternalProject_add
command, which is how the lvgl library is retrieved and built.
Switching to direct invocation of cmake to fix this.

This should fix the build of https://github.com/lvgl/lv_lib_split_jpg/pull/30